### PR TITLE
added test as new test block identifiers

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -21,6 +21,9 @@ export const defaultConfig: Configuration = {
         "toThrowErrorMatchingSnapshot"
     ],
     testBlockIdentifiers: [
+        "test",
+        "test.only",
+        "test.skip",
         "it",
         "it.only",
         "it.skip",


### PR DESCRIPTION
This is what Jest uses in its public documentation: https://facebook.github.io/jest/docs/en/api.html

Sadly I haven't gotten the language plugin to work for me so far :( But the VS Code extension seems to work fine 👍 