### PR TITLE
Support vitest flavored snapshot file

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,11 @@ To pass your values, add them in tsconfig.json:
         ]
     }]
 ```
+
+**snapshotFileFlavor**
+Snapshot file flavor, default:
+```json
+"jest"
+```
+
+You can set it to `vitest` to support [vitest snapshots](https://vitest.dev/guide/snapshot.html).

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,6 +31,8 @@ export interface Configuration {
      * Note: vscode doesn't render correctly both css + jsx in separate tags, so this option doesn't do anything now
      */
     extractCSSForJSTag: boolean;
+
+    snapshotFileFlavor: 'jest' | 'vitest';
 }
 
 export const defaultConfig: Configuration = {
@@ -56,4 +58,5 @@ export const defaultConfig: Configuration = {
     snapshotDir: "__snapshots__",
     useJSTagsForSnapshotHover: false,
     extractCSSForJSTag: true,
+    snapshotFileFlavor: 'jest',
 }

--- a/src/getsnapshot.ts
+++ b/src/getsnapshot.ts
@@ -40,9 +40,9 @@ export function tryGetSnapshotForPosition(
 
                 const customName = node.parent.parent.arguments.find(arg => ts.isStringLiteral(arg));
                 // let snapshotName = blockInfo.blockNames.join(" ") + " " + (snapshotCallsInBlock + 1);
-                let snapshotName = blockInfo.blockNames.join(" ");
+                let snapshotName = blockInfo.blockNames.join(config.snapshotFileFlavor === "vitest" ? " > " : " ");
                 if (customName) {
-                    snapshotName += ": " + (customName as ts.StringLiteralLike).text + " " + snapshotCallsInBlock.namedCalls[(customName as ts.StringLiteralLike).text];
+                    snapshotName += (config.snapshotFileFlavor === "vitest" ? " > " : ": ") + (customName as ts.StringLiteralLike).text + " " + snapshotCallsInBlock.namedCalls[(customName as ts.StringLiteralLike).text];
                 } else {
                     snapshotName += " " + (snapshotCallsInBlock.anonymousCalls);
                 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,9 @@ function init(modules: { typescript: typeof ts_module }) {
         if (typeof info.config.extractCSSForJSTag !== "undefined") {
             config.extractCSSForJSTag = info.config.extractCSSForJSTag;
         }
+        if (typeof info.config.snapshotFileFlavor !== "undefined") {
+            config.snapshotFileFlavor = info.config.snapshotFileFlavor
+        }
 
         for (const k in oldLS) {
             (proxy as any)[k] = function () {


### PR DESCRIPTION
https://vitest.dev/guide/snapshot.html#_3-chevron-is-used-as-a-separator-instead-of-colon-for-custom-messages

![image](https://github.com/asvetliakov/typescript-snapshots-plugin/assets/13151189/ee829aac-0db1-4605-be5e-9c9c7a99d07c)
